### PR TITLE
Humanitarian additions

### DIFF
--- a/stats/analytics.py
+++ b/stats/analytics.py
@@ -1291,7 +1291,10 @@ class ActivityStats(CommonSharedElements):
             ) else 0,
             'uses_humanitarian_clusters_vocab': 1 if (
                 is_humanitarian and self._version() in ['2.02', '2.03'] and self.element.xpath('sector/@vocabulary="10"')
-            ) else 0
+            ) else 0,
+            'uses_humanitarian_clusters_vocab_without_humanitarian': 1 if (
+                (not is_humanitarian) and self._version() in ['2.02', '2.03'] and self.element.xpath('sector/@vocabulary="10"')
+            ) else 0,
         }
 
     def _transaction_type_code(self, transaction):

--- a/stats/analytics.py
+++ b/stats/analytics.py
@@ -1295,6 +1295,12 @@ class ActivityStats(CommonSharedElements):
             'uses_humanitarian_clusters_vocab_without_humanitarian': 1 if (
                 (not is_humanitarian) and self._version() in ['2.02', '2.03'] and self.element.xpath('sector/@vocabulary="10"')
             ) else 0,
+            'uses_humanitarian_glide_codes': 1 if (
+                is_humanitarian and self._version() in ['2.02', '2.03'] and self.element.xpath('humanitarian-scope/@vocabulary') and self.element.xpath('humanitarian-scope/@vocabulary="1-2"')
+            ) else 0,
+            'uses_humanitarian_glide_codes_without_humanitarian': 1 if (
+                (not is_humanitarian) and self._version() in ['2.02', '2.03'] and self.element.xpath('humanitarian-scope/@vocabulary') and self.element.xpath('humanitarian-scope/@vocabulary="1-2"')
+            ) else 0,
         }
 
     def _transaction_type_code(self, transaction):

--- a/stats/analytics.py
+++ b/stats/analytics.py
@@ -1319,6 +1319,16 @@ class ActivityStats(CommonSharedElements):
         return out
 
     @returns_numberdictdict
+    def activity_dates_humanitarian(self):
+        out = defaultdict(lambda: defaultdict(int))
+        if ('humanitarian' in self.element.attrib) and (self.element.attrib['humanitarian'] in ['1', 'true']):
+            for activity_date in self.element.findall('activity-date'):
+                type_code = activity_date.attrib.get('type')
+                act_date = iso_date(activity_date)
+                out[type_code][str(act_date)] += 1
+        return out
+
+    @returns_numberdictdict
     def _count_transactions_by_type_by_year(self):
         out = defaultdict(lambda: defaultdict(int))
         for transaction in self.element.findall('transaction'):

--- a/stats/analytics.py
+++ b/stats/analytics.py
@@ -1286,6 +1286,9 @@ class ActivityStats(CommonSharedElements):
             'contains_humanitarian_scope': 1 if (
                 is_humanitarian and self._version() in ['2.02', '2.03'] and all_true_and_not_empty(self.element.xpath('humanitarian-scope/@type')) and all_true_and_not_empty(self.element.xpath('humanitarian-scope/@code'))
             ) else 0,
+            'contains_humanitarian_scope_without_humanitarian': 1 if (
+                (not is_humanitarian) and self._version() in ['2.02', '2.03'] and all_true_and_not_empty(self.element.xpath('humanitarian-scope/@type')) and all_true_and_not_empty(self.element.xpath('humanitarian-scope/@code'))
+            ) else 0,
             'uses_humanitarian_clusters_vocab': 1 if (
                 is_humanitarian and self._version() in ['2.02', '2.03'] and self.element.xpath('sector/@vocabulary="10"')
             ) else 0

--- a/stats/analytics.py
+++ b/stats/analytics.py
@@ -1301,6 +1301,12 @@ class ActivityStats(CommonSharedElements):
             'uses_humanitarian_glide_codes_without_humanitarian': 1 if (
                 (not is_humanitarian) and self._version() in ['2.02', '2.03'] and self.element.xpath('humanitarian-scope/@vocabulary') and self.element.xpath('humanitarian-scope/@vocabulary="1-2"')
             ) else 0,
+            'uses_humanitarian_hrp_codes': 1 if (
+                is_humanitarian and self._version() in ['2.02', '2.03'] and self.element.xpath('humanitarian-scope/@vocabulary') and self.element.xpath('humanitarian-scope/@vocabulary="2-1"')
+            ) else 0,
+            'uses_humanitarian_hrp_codes_without_humanitarian': 1 if (
+                (not is_humanitarian) and self._version() in ['2.02', '2.03'] and self.element.xpath('humanitarian-scope/@vocabulary') and self.element.xpath('humanitarian-scope/@vocabulary="2-1"')
+            ) else 0,
         }
 
     def _transaction_type_code(self, transaction):

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -722,6 +722,42 @@ def test_humanitarian_scope_with_humanitarian(version, hum_attrib_val):
 
 
 @pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['0', 'false'])
+def test_glide_codes_without_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains GLIDE codes in the humanitarian scope,
+    when the humanitarian attribute is set to false.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <humanitarian-scope vocabulary="1-2" type="xx" code="xx" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['uses_humanitarian_glide_codes'] == 0
+    assert activity_stats.humanitarian()['uses_humanitarian_glide_codes_without_humanitarian'] == 1
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['1', 'true'])
+def test_glide_codes_with_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains GLIDE codes in the humanitarian scope,
+    when the humanitarian attribute is set to true.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <humanitarian-scope vocabulary="1-2" type="xx" code="xx" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['uses_humanitarian_glide_codes'] == 1
+    assert activity_stats.humanitarian()['uses_humanitarian_glide_codes_without_humanitarian'] == 0
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
 @pytest.mark.parametrize('hum_attrib_val', ['1', 'true'])
 def test_humanitarian_clusters_valid(version, hum_attrib_val):
     """

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -758,6 +758,42 @@ def test_glide_codes_with_humanitarian(version, hum_attrib_val):
 
 
 @pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['0', 'false'])
+def test_hrp_codes_without_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains HRP codes in the humanitarian scope,
+    when the humanitarian attribute is set to false.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <humanitarian-scope vocabulary="2-1" type="xx" code="xx" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['uses_humanitarian_hrp_codes'] == 0
+    assert activity_stats.humanitarian()['uses_humanitarian_hrp_codes_without_humanitarian'] == 1
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['1', 'true'])
+def test_hrp_codes_with_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains HRP codes in the humanitarian scope,
+    when the humanitarian attribute is set to true.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <humanitarian-scope vocabulary="2-1" type="xx" code="xx" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['uses_humanitarian_hrp_codes'] == 1
+    assert activity_stats.humanitarian()['uses_humanitarian_hrp_codes_without_humanitarian'] == 0
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
 @pytest.mark.parametrize('hum_attrib_val', ['1', 'true'])
 def test_humanitarian_clusters_valid(version, hum_attrib_val):
     """

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -804,3 +804,39 @@ def test_humanitarian_clusters_invalid(version, hum_attrib_val,
         </iati-activity>
     '''.format(hum_attrib_val, sector_vocabulary_code))
     assert activity_stats.humanitarian()['uses_humanitarian_clusters_vocab'] == 0
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['0', 'false'])
+def test_humanitarian_clusters_without_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains a sector defined by the 'Humanitarian Global Clusters' sector vocabulary,
+    when the humanitarian attribute is set to false.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <sector vocabulary="10" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['uses_humanitarian_clusters_vocab'] == 0
+    assert activity_stats.humanitarian()['uses_humanitarian_clusters_vocab_without_humanitarian'] == 1
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['1', 'true'])
+def test_humanitarian_clusters_with_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains a sector defined by the 'Humanitarian Global Clusters' sector vocabulary,
+    when the humanitarian attribute is set to true.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <sector vocabulary="10" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['uses_humanitarian_clusters_vocab'] == 1
+    assert activity_stats.humanitarian()['uses_humanitarian_clusters_vocab_without_humanitarian'] == 0

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -686,6 +686,42 @@ def test_humanitarian_scope_but_humanitarian_is_false(version, hum_attrib_val_fa
 
 
 @pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['0', 'false'])
+def test_humanitarian_scope_without_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains a humanitarian scope,
+    when the humanitarian attribute is set to false.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <humanitarian-scope type="xx" code="xx" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['contains_humanitarian_scope'] == 0
+    assert activity_stats.humanitarian()['contains_humanitarian_scope_without_humanitarian'] == 1
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
+@pytest.mark.parametrize('hum_attrib_val', ['1', 'true'])
+def test_humanitarian_scope_with_humanitarian(version, hum_attrib_val):
+    """
+    Detect that an activity contains a humanitarian scope,
+    when the humanitarian attribute is set to true.
+    """
+    activity_stats = MockActivityStats(version)
+
+    activity_stats.element = etree.fromstring('''
+        <iati-activity humanitarian="{0}">
+           <humanitarian-scope type="xx" code="xx" />
+        </iati-activity>
+    '''.format(hum_attrib_val))
+    assert activity_stats.humanitarian()['contains_humanitarian_scope'] == 1
+    assert activity_stats.humanitarian()['contains_humanitarian_scope_without_humanitarian'] == 0
+
+
+@pytest.mark.parametrize('version', ['2.02', '2.03'])
 @pytest.mark.parametrize('hum_attrib_val', ['1', 'true'])
 def test_humanitarian_clusters_valid(version, hum_attrib_val):
     """


### PR DESCRIPTION
Adds some additional properties to the `humanitarian.json` outputs, to check whether HRP, GLIDE codes exist, and to add additional properties where clusters, HRP and GLIDE codes exist when the `humanitarian` flag is`false`.