### PR TITLE
Update humanitarian codes

### DIFF
--- a/stats/analytics.py
+++ b/stats/analytics.py
@@ -1255,7 +1255,7 @@ class ActivityStats(CommonSharedElements):
 
     @returns_numberdict
     def humanitarian(self):
-        humanitarian_sectors_dac_5_digit = ['72010', '72040', '72050', '73010', '74010', '74020']
+        humanitarian_sectors_dac_5_digit = ['72010', '72011', '72012', '72040', '72050', '73010', '74010', '74020']
         humanitarian_sectors_dac_3_digit = ['720', '730', '740']
 
         # logic around use of the @humanitarian attribute

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -386,7 +386,7 @@ def test_humanitarian_sector_true_transaction_invalid_version(version, sector, x
 
 
 @pytest.mark.parametrize('major_version', ['1', '2'])
-@pytest.mark.parametrize('sector', [-89, 'not_a_code', HUMANITARIAN_SECTOR_CODES_5_DIGITS[0] + 1, HUMANITARIAN_SECTOR_CODES_3_DIGITS[0] + 1, HUMANITARIAN_SECTOR_CODES_5_DIGITS[-1] - 1, HUMANITARIAN_SECTOR_CODES_3_DIGITS[-1] - 1])
+@pytest.mark.parametrize('sector', [-89, 'not_a_code', 11110, 111, 12220, 122])
 @pytest.mark.parametrize('xml', ['''
         <iati-activity>
             <sector code="{0}" />

--- a/stats/tests/test_humanitarian.py
+++ b/stats/tests/test_humanitarian.py
@@ -25,7 +25,7 @@ class MockActivityStats(ActivityStats):
         return self._major_version() + '.' + self._minor_version()
 
 
-HUMANITARIAN_SECTOR_CODES_5_DIGITS = [72010, 72040, 72050, 73010, 74010, 74020]
+HUMANITARIAN_SECTOR_CODES_5_DIGITS = [72010, 72011, 72012, 72040, 72050, 73010, 74010, 74020]
 HUMANITARIAN_SECTOR_CODES_3_DIGITS = [720, 730, 740]
 
 


### PR DESCRIPTION
Include two missing humanitarian codes `72011` and `72012`